### PR TITLE
Fix header

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ header{
     background-color: rgba(82, 102, 116, 0.6);
     width: 63%;
     display: inline-block;
-    height: 5em;
+    height: auto;
     border-radius: 20px 20px 0 0;
     margin-top: 0.5em;
 }


### PR DESCRIPTION
A simple fix to prevent menu from floating outside the header and behind the photos :)

#### Before
<img width="940" alt="Captura de Tela 2021-09-28 às 10 27 37" src="https://user-images.githubusercontent.com/10306/135096951-40927838-6fab-4bc1-aae9-84a0dfc86e48.png">

#### After
<img width="942" alt="Captura de Tela 2021-09-28 às 10 27 57" src="https://user-images.githubusercontent.com/10306/135096977-363b07bb-c419-432b-9214-96803850c1d1.png">
